### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/src/drive-homepage/main.js
+++ b/src/drive-homepage/main.js
@@ -18,7 +18,7 @@ const [reserveText, reserveAddress] = reserveImageContainer.querySelectorAll('p-
 for (const result of reserveResults) {
   result.addEventListener('mouseover', (e) => {
     reserveImg.src = e.target.dataset.img;
-    reserveText.innerHTML = e.target.textContent;
+    reserveText.textContent = e.target.textContent;
     reserveAddress.innerHTML = e.target.dataset.address;
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/porsche-design-system/templates/security/code-scanning/12](https://github.com/porsche-design-system/templates/security/code-scanning/12)

To fix this issue, avoid assigning values derived from DOM text (`textContent`, potentially attacker-controlled) to `.innerHTML`. Instead, assign to `.textContent`, which will always treat the input as plain text and not interpret it as HTML. On line 21, change `reserveText.innerHTML = e.target.textContent;` to `reserveText.textContent = e.target.textContent;` to ensure that any text shown is not parsed as HTML. No new imports or dependencies are required. The edit is localized to line 21 in src/drive-homepage/main.js.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
