### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contribution.yml
+++ b/.github/workflows/contribution.yml
@@ -1,4 +1,6 @@
 name: 'Contribution'
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/porsche-design-system/templates/security/code-scanning/4](https://github.com/porsche-design-system/templates/security/code-scanning/4)

To address this issue, set an explicit `permissions` block at the top (root) of the workflow file, immediately after the `name` field and before the `on` field. For most workflows, the minimal required permission is `contents: read`, unless write access is expressly needed elsewhere. If any job (such as deploy) needs a different set of permissions, those jobs should specify an overriding `permissions` block, but this is not shown in the provided snippet.  
**Edit the file `.github/workflows/contribution.yml` as follows:**  
Add the following lines after `name: 'Contribution'` (line 1):  
```yaml
permissions:
  contents: read
```
No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
